### PR TITLE
Adding a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,28 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.1.0  # Use the latest stable version here
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3.11
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        language_version: python3.11
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Run pytest
+        entry: pytest
+        language: system
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0  # Use the latest stable version here
+    hooks:
+      - id: black
+        language_version: python3.11

--- a/breadsticks.py
+++ b/breadsticks.py
@@ -1,3 +1,0 @@
-import typing
-
-print("hiyaaa")

--- a/breadsticks.py
+++ b/breadsticks.py
@@ -1,0 +1,3 @@
+import typing
+
+print("hiyaaa")


### PR DESCRIPTION
Adding a pre commit hook to check formatting [black], apply linter [ruff], some additional pre-commit checks, and also run all pytests, ensuring they pass, if applicable.